### PR TITLE
scrapy 2.6.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,10 +14,13 @@ source:
   sha256: 56fd55a59d0f329ce752892358abee5a6b50b4fc55a40420ea317dc617553827
 
 build:
-  script: "{{ PYTHON }} -m pip install . --no-deps -vv"
+  number: 0
+  # scrapy, pydispatcher >=2.0.5, queuelib, and parsel >=1.5 
+  # currently aren't available on s390x
+  skip: True  # [s390x or py<36]
+  script: {{ PYTHON }} -m pip install . --no-deps -vv
   entry_points:
     - scrapy = scrapy.cmdline:execute
-  number: 0
 
 # The requirements below shall match the requirements from the target package
 # version (check setup.py for changes).
@@ -25,35 +28,47 @@ requirements:
   host:
     - python
     - pip
-
+    - setuptools
+    - wheel
   run:
     - python
-    - setuptools
-    - twisted >=13.1.0  # [not win]
-    - twisted >=16.4.0  # [win]
+    - pywin32  # [win]
+    # Same order as setup.py:
+    - twisted >=17.9.0
+    - cryptography >=2.0
+    - cssselect >=0.9.1
+    - itemloaders >=1.0.1
+    - parsel >=1.5.0
+    - pyOpenSSL >=16.2.0
+    - queuelib >=1.4.2
+    - service_identity >=16.0.0
     - w3lib >=1.17.0
-    - queuelib
-    - itemadapter
-    - lxml
-    - pyopenssl
-    - cssselect >=0.9
-    - six >=1.5.2
-    - parsel >=1.5
+    - zope.interface >=4.1.3
+    - protego >=0.1.15
+    - itemadapter >=0.1.0
+    - setuptools
+    - tldextract
+    # cpython depenencies
+    - lxml >=3.5.0
     - pydispatcher >=2.0.5
-    - service_identity
+    # https://github.com/scrapy/scrapy/pull/5208
+    - libxml2 <2.9.11
 
 test:
   imports:
     - scrapy
-
+  requires:
+    - pip
   commands:
     # Ideally, we will run tests here but we require to provide the tests
     # requirements first.
+    - pip check
     - scrapy bench
+    - scrapy --help
 
 about:
   home: https://scrapy.org/
-  license: BSD 3-Clauses
+  license: BSD-3-Clause
   license_file: LICENSE
   summary: A high-level Python Screen Scraping framework
   description: |

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -3,7 +3,7 @@
 # https://github.com/scrapy/scrapy/wiki/Scrapy-release-procedure#conda-packages
 #
 {% set name = "Scrapy" %}
-{% set version = "2.4.1" %}
+{% set version = "2.6.1" %}
 
 package:
   name: {{ name|lower }}
@@ -11,7 +11,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 68c48f01a58636bdf0f6fcd5035a19ecf277b58af24bd70c36dc6e556df3e005
+  sha256: 56fd55a59d0f329ce752892358abee5a6b50b4fc55a40420ea317dc617553827
 
 build:
   script: "{{ PYTHON }} -m pip install . --no-deps -vv"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,8 @@ build:
   number: 0
   # scrapy, pydispatcher >=2.0.5, queuelib, and parsel >=1.5 
   # currently aren't available on s390x
-  skip: True  # [s390x or py<36  or py>=310]
+  # It seems like scrapy 2.6.1 or its dependencies still do not support python 3.10
+  skip: True  # [s390x or py<36 or py>=310]
   script: {{ PYTHON }} -m pip install . --no-deps -vv
   entry_points:
     - scrapy = scrapy.cmdline:execute

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -68,7 +68,7 @@ test:
 
 about:
   home: https://scrapy.org/
-  license: BSD-3-Clause
+  license: BSD-3-Clause-Clear
   license_file: LICENSE
   summary: A high-level Python Screen Scraping framework
   description: |

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ build:
   number: 0
   # scrapy, pydispatcher >=2.0.5, queuelib, and parsel >=1.5 
   # currently aren't available on s390x
-  skip: True  # [s390x or py<36]
+  skip: True  # [s390x or py<36  or py>=310]
   script: {{ PYTHON }} -m pip install . --no-deps -vv
   entry_points:
     - scrapy = scrapy.cmdline:execute

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,8 +17,7 @@ build:
   number: 0
   # scrapy, pydispatcher >=2.0.5, queuelib, and parsel >=1.5 
   # currently aren't available on s390x
-  # It seems like scrapy 2.6.1 or its dependencies still do not support python 3.10
-  skip: True  # [s390x or py<36 or py>=310]
+  skip: True  # [s390x or py<36]
   script: {{ PYTHON }} -m pip install . --no-deps -vv
   entry_points:
     - scrapy = scrapy.cmdline:execute
@@ -52,8 +51,7 @@ requirements:
     # cpython depenencies
     - lxml >=3.5.0
     - pydispatcher >=2.0.5
-    # https://github.com/scrapy/scrapy/pull/5208
-    - libxml2 <2.9.11
+    - libxml2
 
 test:
   imports:


### PR DESCRIPTION
Update scrapy to 2.6.1

Bug Tracker: new open issues https://github.com/scrapy/scrapy/issues
Github releases:  https://github.com/scrapy/scrapy/releases
Upstream license:  License file:  https://github.com/scrapy/scrapy/blob/master/LICENSE
Install: https://docs.scrapy.org/en/latest/intro/install.html
Upstream setup.py:  https://github.com/scrapy/scrapy/blob/2.6.1/setup.py

The package scrapy is mentioned inside the packages:
cssselect | itemadapter | itemloaders | parsel | protego | queuelib |  w3lib |
