### PR TITLE
scrapy 2.6.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -3,7 +3,7 @@
 # https://github.com/scrapy/scrapy/wiki/Scrapy-release-procedure#conda-packages
 #
 {% set name = "Scrapy" %}
-{% set version = "2.6.1" %}
+{% set version = "2.6.2" %}
 
 package:
   name: {{ name|lower }}
@@ -11,7 +11,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 56fd55a59d0f329ce752892358abee5a6b50b4fc55a40420ea317dc617553827
+  sha256: 55e21181165f25337105fff1efc8393296375cea7de699a7e703bbd265595f26
 
 build:
   number: 0
@@ -51,7 +51,10 @@ requirements:
     # cpython depenencies
     - lxml >=3.5.0
     - pydispatcher >=2.0.5
-    - libxml2
+    # See https://github.com/scrapy/scrapy/pull/5208 (on 16 Jul 2021). But after that date 
+    # lxml was fixed https://github.com/AnacondaRecipes/lxml-feedstock/commit/173869446fd13f3189291ba14af27958cd1bc1c6,
+    # exclusions due to https://bugs.launchpad.net/lxml/+bug/1928795
+    - libxml2 >=2.9.2,!=2.9.11,!=2.9.12
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -70,7 +70,8 @@ test:
 
 about:
   home: https://scrapy.org/
-  license: BSD-3-Clause-Clear
+  license: BSD-3-Clause
+  license_family: BSD
   license_file: LICENSE
   summary: A high-level Python Screen Scraping framework
   description: |


### PR DESCRIPTION
License: https://github.com/scrapy/scrapy/blob/2.6.2/LICENSE
Changelog: https://docs.scrapy.org/en/2.6/news.html#scrapy-2-6-2-2022-07-25
Requirements: https://github.com/scrapy/scrapy/blob/2.6.2/setup.py

Actions: 
1. Fix `libxml2` pinning and add a comment about exclusions, see:
- https://github.com/scrapy/scrapy/pull/5208 (created on 16 Jul 2021)
- https://github.com/AnacondaRecipes/lxml-feedstock/commit/173869446fd13f3189291ba14af27958cd1bc1c6
- libxml2 exclusions due to https://bugs.launchpad.net/lxml/+bug/1928795