### PR TITLE
scrapy 2.12.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/sybil-feedstock/pr1/e9f6c0d
-  - https://staging.continuum.io/prefect/fs/libxml2-feedstock/pr18/330077e
-  - https://staging.continuum.io/prefect/fs/lxml-feedstock/pr15/78146f2

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,3 @@
 channels:
   - https://staging.continuum.io/prefect/fs/sybil-feedstock/pr1/e9f6c0d
-  - https://staging.continuum.io/prefect/fs/lxml-feedstock/pr14/c54098b
+  - https://staging.continuum.io/prefect/fs/lxml-feedstock/pr15/78146f2

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,3 @@
 channels:
   - https://staging.continuum.io/prefect/fs/sybil-feedstock/pr1/e9f6c0d
+  - https://staging.continuum.io/prefect/fs/lxml-feedstock/pr14/c54098b

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,4 @@
 channels:
   - https://staging.continuum.io/prefect/fs/sybil-feedstock/pr1/e9f6c0d
+  - https://staging.continuum.io/prefect/fs/libxml2-feedstock/pr18/330077e
   - https://staging.continuum.io/prefect/fs/lxml-feedstock/pr15/78146f2

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,1 +1,2 @@
-aggregate_branch: 3.12
+channels:
+  - https://staging.continuum.io/prefect/fs/lxml-feedstock/pr14/c54098b

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
 channels:
-  - https://staging.continuum.io/prefect/fs/lxml-feedstock/pr14/c54098b
+  - https://staging.continuum.io/prefect/fs/sybil-feedstock/pr1/e9f6c0d

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -61,6 +61,7 @@ test:
     - pytest
     - pytest-cov
     - pytest-xdist
+    - sybil >= 1.3.0  # https://github.com/cjw296/sybil/issues/20#issuecomment-605433422
     - testfixtures
     - uvloop # [not win]
     - ipython

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -68,26 +68,10 @@ test:
     - uvloop # [not win]
     - ipython
   commands:
+    - pip check
     - scrapy version -v
-    - pip install setuptools-scm  # required by indirect dependency pytest-forked
-    # test requirements unavailable on conda:
-    - pip install sybil
-
-    # - mv scrapy _scrapy
-    # https://github.com/scrapy/scrapy/issues/2653#issuecomment-598610517
-    - rm tests/test_utils_asyncio.py  # [win and py==38]
-    - rm -f tests/test_command_parse.py tests/test_commands.py tests/test_crawler.py tests/test_downloader_handlers.py tests/test_downloader_handlers_http2.py  # [osx]
-    # Test failures since Scrapy 2.4:
-    - rm -f tests/test_command_check.py tests/test_command_parse.py tests/test_commands.py tests/test_crawler.py tests/test_feedexport.py
-    # test_convert_image fails because expected vs actual color does not match
-    # by 1 bit (#0079FF vs #0080FF)
-    - rm -f tests/test_pipeline_images.py
-    # MediaPipelineDeprecatedMethodsTestCase leaves files that interfere with its tests
-    - rm -f tests/test_pipeline_media.py
-    # The removed tests/test_pipeline_media.py file is a dependency
-    - rm -f tests/test_pipeline_files.py
-    # Started failing in 2.11.1
-    - rm -f tests/test_command_shell.py
+    - scrapy bench
+    - scrapy --help
     # win-64: FTP tests: connection refused on 127.0.0.1
     # win-64: test_shutdown_forced
     # linux-s390x: test_utf16 fails due to endianness

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -68,10 +68,26 @@ test:
     - uvloop # [not win]
     - ipython
   commands:
-    - pip check
     - scrapy version -v
-    - scrapy bench
-    - scrapy --help
+    - pip install setuptools-scm  # required by indirect dependency pytest-forked
+    # test requirements unavailable on conda:
+    - pip install sybil
+
+    # - mv scrapy _scrapy
+    # https://github.com/scrapy/scrapy/issues/2653#issuecomment-598610517
+    - rm tests/test_utils_asyncio.py  # [win and py==38]
+    - rm -f tests/test_command_parse.py tests/test_commands.py tests/test_crawler.py tests/test_downloader_handlers.py tests/test_downloader_handlers_http2.py  # [osx]
+    # Test failures since Scrapy 2.4:
+    - rm -f tests/test_command_check.py tests/test_command_parse.py tests/test_commands.py tests/test_crawler.py tests/test_feedexport.py
+    # test_convert_image fails because expected vs actual color does not match
+    # by 1 bit (#0079FF vs #0080FF)
+    - rm -f tests/test_pipeline_images.py
+    # MediaPipelineDeprecatedMethodsTestCase leaves files that interfere with its tests
+    - rm -f tests/test_pipeline_media.py
+    # The removed tests/test_pipeline_media.py file is a dependency
+    - rm -f tests/test_pipeline_files.py
+    # Started failing in 2.11.1
+    - rm -f tests/test_command_shell.py
     # win-64: FTP tests: connection refused on 127.0.0.1
     # win-64: test_shutdown_forced
     # linux-s390x: test_utf16 fails due to endianness

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -67,6 +67,7 @@ test:
     - pexpect  # [win]
   commands:
     - pip check
+    - set "PYTHONIOENCODING=utf8"  # [win]
     - scrapy version -v
     - scrapy bench
     - scrapy --help

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,12 +28,12 @@ requirements:
     - wheel
   run:
     - python
-    - twisted >=18.9.0
-    - cryptography >=36.0.0
+    - twisted >=21.7.0
+    - cryptography >=37.0.0
     - cssselect >=0.9.1
     - itemloaders >=1.0.1
     - parsel >=1.5.0
-    - pyopenssl >=21.0.0
+    - pyopenssl >=22.0.0
     - queuelib >=1.4.2
     - service_identity >=18.1.0
     - w3lib >=1.17.0
@@ -43,7 +43,7 @@ requirements:
     - setuptools
     - packaging
     - tldextract
-    - lxml >=4.4.1
+    - lxml >=4.6.0
     - pydispatcher >=2.0.5
     - defusedxml >=0.7.1
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -58,6 +58,7 @@ test:
     - pip
     # Tests requirements
     - attrs
+    - pygments
     - pytest
     - pytest-cov
     - pytest-xdist

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,8 +2,8 @@
 # See the guidelines for updating this recipe for new releases:
 # https://github.com/scrapy/scrapy/wiki/Scrapy-release-procedure#conda-packages
 #
-{% set name = "Scrapy" %}
-{% set version = "2.11.1" %}
+{% set name = "scrapy" %}
+{% set version = "2.11.2" %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -58,15 +58,13 @@ test:
     - pip
     # Tests requirements
     - attrs
-    - pexpect
-    # - pyftpdlib >=1.5.8
     - pytest
     - pytest-cov
     - pytest-xdist
-    # - sybil >=1.3.0
     - testfixtures
     - uvloop # [not win]
     - ipython
+    - pexpect  # [win]
   commands:
     - pip check
     - scrapy version -v

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -76,7 +76,6 @@ test:
     # test_start_requests_laziness sporadic failures
     # test_mediatype_parameters fails due to regex issue in parse_data_uri
     # Https10TestCase, Http11ProxyTestCase, EngineTest, BytesReceivedEngineTest, WebClientSSLTestCase see: https://github.com/scrapy/scrapy/issues/5961
-    - set "PYTHONIOENCODING=utf8"  # [win]
     - pytest -n auto -k "not (FTPTestCase or FTPFeedStorageTest or TestFTPFileStore or test_utf16 or test_start_requests_laziness or test_mediatype_parameters or Https10TestCase or Http11ProxyTestCase or EngineTest or test_shutdown_forced or BytesReceivedEngineTest or WebClientSSLTestCase or test_delay)"
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -78,6 +78,7 @@ test:
     # test_start_requests_laziness sporadic failures
     # test_mediatype_parameters fails due to regex issue in parse_data_uri
     # Https10TestCase, Http11ProxyTestCase, EngineTest, BytesReceivedEngineTest, WebClientSSLTestCase see: https://github.com/scrapy/scrapy/issues/5961
+    - set "PYTHONIOENCODING=utf8"  # [win]
     - pytest -n auto -k "not (FTPTestCase or FTPFeedStorageTest or TestFTPFileStore or test_utf16 or test_start_requests_laziness or test_mediatype_parameters or Https10TestCase or Http11ProxyTestCase or EngineTest or test_shutdown_forced or BytesReceivedEngineTest or WebClientSSLTestCase or test_delay)"
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,7 +40,6 @@ requirements:
     - zope.interface >=5.1.0
     - protego >=0.1.15
     - itemadapter >=0.1.0
-    - setuptools
     - packaging
     - tldextract
     - lxml >=4.6.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -67,7 +67,6 @@ test:
     - pexpect  # [win]
   commands:
     - pip check
-    - set "PYTHONIOENCODING=utf8"  # [win]
     - scrapy version -v
     - scrapy bench
     - scrapy --help
@@ -77,6 +76,7 @@ test:
     # test_start_requests_laziness sporadic failures
     # test_mediatype_parameters fails due to regex issue in parse_data_uri
     # Https10TestCase, Http11ProxyTestCase, EngineTest, BytesReceivedEngineTest, WebClientSSLTestCase see: https://github.com/scrapy/scrapy/issues/5961
+    - set "PYTHONIOENCODING=utf8"  # [win]
     - pytest -n auto -k "not (FTPTestCase or FTPFeedStorageTest or TestFTPFileStore or test_utf16 or test_start_requests_laziness or test_mediatype_parameters or Https10TestCase or Http11ProxyTestCase or EngineTest or test_shutdown_forced or BytesReceivedEngineTest or WebClientSSLTestCase or test_delay)"
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
 
 build:
   number: 0
-  skip: True  # [py<38]
+  skip: True  # [py<39]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   entry_points:
     - scrapy = scrapy.cmdline:execute

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -3,7 +3,7 @@
 # https://github.com/scrapy/scrapy/wiki/Scrapy-release-procedure#conda-packages
 #
 {% set name = "scrapy" %}
-{% set version = "2.11.2" %}
+{% set version = "2.12.0" %}
 
 package:
   name: {{ name|lower }}
@@ -11,7 +11,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: dfbd565384fc3fffeba121f5a3a2d0899ac1f756d41432ca0879933fbfb3401d
+  sha256: d66d6e76009b12447604196875a463b61d10721140032a8084a0a52df7f4788f
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 733a039c7423e52b69bf2810b5332093d4e42a848460359c07b02ecff8f73ebe
+  sha256: dfbd565384fc3fffeba121f5a3a2d0899ac1f756d41432ca0879933fbfb3401d
 
 build:
   number: 0
@@ -45,6 +45,7 @@ requirements:
     - tldextract
     - lxml >=4.4.1
     - pydispatcher >=2.0.5
+    - defusedxml >=0.7.1
 
 test:
   source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -58,13 +58,15 @@ test:
     - pip
     # Tests requirements
     - attrs
+    - pexpect
+    # - pyftpdlib >=1.5.8
     - pytest
     - pytest-cov
     - pytest-xdist
+    # - sybil >=1.3.0
     - testfixtures
     - uvloop # [not win]
     - ipython
-    - pexpect # [win]
   commands:
     - pip check
     - scrapy version -v


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-5595](https://anaconda.atlassian.net/browse/PKG-5595)
- [Upstream repository](https://github.com/scrapy/scrapy/tree/2.12.0)
- [Upstream changelog/diff](https://github.com/scrapy/scrapy/releases)

### Explanation of changes:

- Update version and sha256
- Update dependencies
- Update test suite requirements


[PKG-5595]: https://anaconda.atlassian.net/browse/PKG-5595?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ